### PR TITLE
Add minimal card board game prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Card Board Game Engine
+
+This repository contains a very small proof-of-concept for a board card game engine written in HTML/JS. It provides a lobby with basic screens for Collection, Deck Building, Shop, Battle, Arena and an Admin panel that allows creation of new cards.
+
+It is not a complete implementation of the described project, but a starting point that demonstrates how data can be stored in `localStorage` and rendered in a simple interface. All data (cards, packs, enemies, etc.) are stored on the browser side and can be modified through the admin panel.
+
+To run the demo open `src/index.html` in a browser. Everything works locally without a server.
+
+More features can be implemented by expanding the JavaScript code.

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,50 @@
+(function(){
+const screens = ['lobby','collection','deck','shop','battle','arena','admin'];
+function showScreen(id){ screens.forEach(s=>document.getElementById(s).classList.add('hidden')); document.getElementById(id).classList.remove('hidden'); if(id==='collection')renderCollection(); if(id==='deck')renderDeck(); if(id==='shop')renderShop(); if(id==='battle')renderLocations(); if(id==='arena')renderArenas(); if(id==='admin')renderAdmin(); }
+window.showScreen=showScreen;
+window.backToLobby=()=>showScreen('lobby');
+
+let data = JSON.parse(localStorage.getItem('gameData')||'null');
+if(!data){
+  data={cards:[],packs:[],enemies:[],arenas:[],fields:[],decks:[[],[],[],[]],activeDeck:0,collection:{}};
+  initDefaultData();
+  save();
+}
+function save(){localStorage.setItem('gameData',JSON.stringify(data));}
+
+function initDefaultData(){
+  const hero={id:'hero1',name:'Starter Hero',type:'hero',rarity:'common',tags:['warrior'],img:'https://via.placeholder.com/100',info:'Hero'};
+  data.cards.push(hero);
+  addCopies(hero.id,1);
+  const minionNames=['MinionA','MinionB','MinionC','MinionD'];
+  minionNames.forEach((n,i)=>{let c={id:'m'+i,name:n,type:'minion',rarity:'common',tags:['pirate'],img:'https://via.placeholder.com/100',info:n};data.cards.push(c);addCopies(c.id,5);});
+  const spell={id:'s1',name:'Fireball',type:'spell',rarity:'common',img:'https://via.placeholder.com/100',info:'spell'};data.cards.push(spell);addCopies(spell.id,5);
+  const item={id:'i1',name:'Potion',type:'item',rarity:'common',img:'https://via.placeholder.com/100',info:'item'};data.cards.push(item);addCopies(item.id,5);
+  data.decks[0]=['hero1','m0','m0','m1','m1','m2','m2','m3','m3','s1','i1'];
+  while(data.decks[0].length<30) data.decks[0].push('m0');
+  data.activeDeck=0;
+  data.packs.push({id:'p1',name:'Starter Pack',price:10,cards:data.cards.map(c=>c.id)});
+  data.enemies.push({id:'e1',name:'Dummy',deck:data.decks[0],reward:5});
+  data.fields.push({id:'f1',name:'Default Field'});
+  data.arenas.push({id:'a1',name:'Test Arena',enemies:['e1'],price:0});
+}
+function addCopies(id,qty){data.collection[id]=(data.collection[id]||0)+qty;}
+
+function renderCollection(){const list=document.getElementById('cardList');list.innerHTML='';data.cards.forEach(c=>{const count=data.collection[c.id]||0;if(count>0){const div=document.createElement('div');div.className='card';div.innerHTML=`<img src="${c.img}"><div class="info">${c.name}<br>${c.info}<br>x${count}</div>`;list.appendChild(div);}});}
+
+function renderDeck(){const deckTabs=document.getElementById('deckTabs');deckTabs.innerHTML='';for(let i=0;i<4;i++){const btn=document.createElement('button');btn.textContent='Deck '+(i+1);if(data.activeDeck===i)btn.style.fontWeight='bold';btn.onclick=()=>{data.activeDeck=i;save();renderDeck();};deckTabs.appendChild(btn);}const deckCards=document.getElementById('deckCards');deckCards.innerHTML='';data.decks[data.activeDeck].forEach(id=>{const c=data.cards.find(x=>x.id===id);if(c){const div=document.createElement('div');div.className='card';div.innerHTML=`<img src="${c.img}"><div class="info">${c.name}</div>`;deckCards.appendChild(div);}});const coll=document.getElementById('collectionCards');coll.innerHTML='';data.cards.forEach(c=>{const div=document.createElement('div');div.className='card';div.innerHTML=`<img src="${c.img}"><div class="info">${c.name}</div>`;div.onclick=()=>{if(countInDeck(c.id,data.activeDeck)<5 && data.decks[data.activeDeck].length<30){data.decks[data.activeDeck].push(c.id);save();renderDeck();}};coll.appendChild(div);});}
+function countInDeck(id,d){return data.decks[d].filter(x=>x===id).length;}
+
+function renderShop(){const div=document.getElementById('packs');div.innerHTML='';data.packs.forEach(p=>{const b=document.createElement('button');b.textContent=p.name+' - '+p.price+'g';b.onclick=()=>{openPack(p)};div.appendChild(b);});}
+function openPack(p){const results=[];for(let i=0;i<5;i++){const cid=p.cards[Math.floor(Math.random()*p.cards.length)];results.push(cid);addCopies(cid,1);}save();alert('You got: '+results.join(', '));}
+
+function renderLocations(){document.getElementById('board').classList.add('hidden');}
+function startSimpleBattle(){const board=document.getElementById('board');board.innerHTML='';for(let y=0;y<12;y++){for(let x=0;x<12;x++){const cell=document.createElement('div');cell.className='cell';cell.dataset.x=x;cell.dataset.y=y;board.appendChild(cell);}}const hero=document.createElement('div');hero.className='cell hero';hero.textContent='H';board.children[0].replaceWith(hero);const enemy=document.createElement('div');enemy.className='cell enemy-hero';enemy.textContent='E';board.children[143].replaceWith(enemy);board.classList.remove('hidden');}
+
+function renderArenas(){const div=document.getElementById('arenas');div.innerHTML='';data.arenas.forEach(a=>{const b=document.createElement('button');b.textContent=a.name;b.onclick=()=>alert('Start arena '+a.name);div.appendChild(b);});}
+
+function renderAdmin(){const c=document.getElementById('adminContent');c.innerHTML='<p>Select a section</p>';}
+window.showAdmin=section=>{const c=document.getElementById('adminContent');if(section==='cards'){renderAdminCards(c);} else c.textContent='TODO';};
+function renderAdminCards(container){container.innerHTML='';const form=document.createElement('div');form.innerHTML='<h3>New Card</h3><input id="acName" placeholder="Name"><select id="acType"><option value="hero">Hero</option><option value="minion">Minion</option><option value="spell">Spell</option><option value="item">Item</option></select><button id="createCard">Create</button>';
+container.appendChild(form);document.getElementById('createCard').onclick=()=>{const id='c'+Date.now();const name=document.getElementById('acName').value;const type=document.getElementById('acType').value;const card={id,name,type,rarity:'common',img:'https://via.placeholder.com/100',info:''};data.cards.push(card);addCopies(card.id,1);save();alert('Card created');};}
+})();

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Card Board Game</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div id="lobby" class="screen">
+  <h1>Lobby</h1>
+  <button onclick="showScreen('collection')">Collection</button>
+  <button onclick="showScreen('deck')">Decks</button>
+  <button onclick="showScreen('shop')">Shop</button>
+  <button onclick="showScreen('battle')">Battle</button>
+  <button onclick="showScreen('arena')">Arena</button>
+  <button onclick="showScreen('admin')">Admin Panel</button>
+</div>
+
+<div id="collection" class="screen hidden">
+  <h2>Collection</h2>
+  <div id="rarityFilters"></div>
+  <div id="tagFilters"></div>
+  <div id="cardList" class="card-grid"></div>
+  <button onclick="backToLobby()">Back</button>
+</div>
+
+<div id="deck" class="screen hidden">
+  <h2>Deck Builder</h2>
+  <div id="deckTabs"></div>
+  <div id="deckCards" class="card-grid"></div>
+  <div id="collectionCards" class="card-grid small"></div>
+  <button onclick="backToLobby()">Back</button>
+</div>
+
+<div id="shop" class="screen hidden">
+  <h2>Shop</h2>
+  <div id="packs"></div>
+  <button onclick="backToLobby()">Back</button>
+</div>
+
+<div id="battle" class="screen hidden">
+  <h2>Battle</h2>
+  <div id="locations"></div>
+  <button onclick="startSimpleBattle()">Start Battle</button>
+  <div id="board" class="board hidden"></div>
+  <button onclick="backToLobby()">Back</button>
+</div>
+
+<div id="arena" class="screen hidden">
+  <h2>Arena</h2>
+  <div id="arenas"></div>
+  <button onclick="backToLobby()">Back</button>
+</div>
+
+<div id="admin" class="screen hidden">
+  <h2>Admin Panel</h2>
+  <div>
+    <button onclick="showAdmin('cards')">Cards</button>
+    <button onclick="showAdmin('packs')">Packs</button>
+    <button onclick="showAdmin('enemies')">Enemies</button>
+    <button onclick="showAdmin('arenas')">Arenas</button>
+    <button onclick="showAdmin('fields')">Fields</button>
+  </div>
+  <div id="adminContent"></div>
+  <button onclick="backToLobby()">Back</button>
+</div>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,14 @@
+body { font-family: sans-serif; margin:0; padding:0; }
+.screen { padding: 10px; }
+.hidden { display: none; }
+.card-grid { display: flex; flex-wrap: wrap; gap:5px; }
+.card { border:1px solid #333; width:100px; height:150px; position:relative; cursor:pointer; }
+.card img { width:100%; height:100%; object-fit:cover; }
+.card:hover { transform:scale(1.2); z-index:10; }
+.card .info { display:none; position:absolute; top:0; left:0; background:white; width:100%; height:100%; overflow:auto; }
+.card:hover .info { display:block; }
+.board { display:grid; grid-template-columns: repeat(12, 40px); grid-template-rows: repeat(12,40px); gap:1px; }
+.cell { width:40px; height:40px; border:1px solid #ccc; display:flex; align-items:center; justify-content:center; }
+.hero { background:blue; color:white; }
+.enemy-hero { background:red; color:white; }
+.small .card { width:80px; height:120px; }


### PR DESCRIPTION
## Summary
- add HTML/CSS/JS prototype for lobby, deck builder, shop, battle and admin screens
- store data in `localStorage`
- seed game with some starter cards and a simple pack
- document how to run the prototype in README

## Testing
- `echo "no tests" && true`
